### PR TITLE
Use main-function in eastwood.lint

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -25,9 +25,9 @@
                        "-d" "test"
                        "-d" "src/test/clojure"]}
   ;; see https://github.com/jonase/eastwood#running-eastwood-in-a-repl
-  :eastwood {:extra-deps {jonase/eastwood {:mvn/version "0.2.9"}}
-             :main-opts ["-e" "(require,'[eastwood.lint,:as,e])"
-                         "-e" "(e/eastwood,{:source-paths,[\"src\"],:test-paths,[\"test\"]})"]}
+  :eastwood {:extra-deps {jonase/eastwood {:git/url https//github.com/jonase/eastwood 
+                                           :sha "edde2f98413c2c5f199e9d7a6c607d39a6e64454"}}
+             :main-opts ["-m" "eastwood.lint" "{:source-paths,[\"src\"],:test-paths,[\"test\"]}"]}
 
   ;; - see https://github.com/clojure-expectations/expectations
   ;; - run your expectations: clj -A:test:expect:runner


### PR DESCRIPTION
As of https://github.com/jonase/eastwood/commit/edde2f98413c2c5f199e9d7a6c607d39a6e64454 eastwood has a main function, so you can invoke that directly